### PR TITLE
Optional code to use a local copy of marked and ensure interface can run offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .idea
 venv
 dist
+static/node_modules/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ cd exui
 pip install -r requirements.txt
 ```
 
+Optionally, install javascript modules locally, to enable the UI to run when offline (requires Node and npm to be installed):
+```
+cd static
+npm install
+cd ..
+```
+
 Then run the web server with the included server.py:
 
 ```
@@ -43,7 +50,7 @@ python server.py
 Your browser should automatically open on the default IP/port. Config and sessions are stored in `~/exui` by default.
 
 Prebuilt wheels for ExLlamaV2 are available [here](https://github.com/turboderp/exllamav2/releases). Installing 
-the latest version of [Flash Attention](https://github.com/Dao-AILab/flash-attention) is recommended. 
+the latest version of [Flash Attention](https://github.com/Dao-AILab/flash-attention) is recommended.
 
 ### Running in Google Colab
 

--- a/static/package.json
+++ b/static/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "exui",
+  "version": "1.0.0",
+  "description": "<p align=\"center\">",
+  "main": "index.js",
+  "directories": {
+    "doc": "doc"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/turboderp/exui.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/turboderp/exui/issues"
+  },
+  "homepage": "https://github.com/turboderp/exui#readme",
+  "dependencies": {
+    "marked": "^12.0.2"
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
         {% include 'svg_icons.html' %}
     </head>
     <body>
-        <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+        <script src="static/node_modules/marked/marked.min.js" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/npm/marked/marked.min.js'"></script>
         <script type="module" src="{{ url_for('static', filename='util.js') }}"></script>
         <script type="module" src="{{ url_for('static', filename='roles.js') }}"></script>
         <script type="module" src="{{ url_for('static', filename='globals.js') }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,10 @@
         {% include 'svg_icons.html' %}
     </head>
     <body>
-        <script src="static/node_modules/marked/marked.min.js" onerror="this.onerror=null;this.src='https://cdn.jsdelivr.net/npm/marked/marked.min.js'"></script>
+        <script src="static/node_modules/marked/marked.min.js"></script>
+        <script>
+            typeof marked != "undefined" || document.write('<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"><\/script>');
+        </script>
         <script type="module" src="{{ url_for('static', filename='util.js') }}"></script>
         <script type="module" src="{{ url_for('static', filename='roles.js') }}"></script>
         <script type="module" src="{{ url_for('static', filename='globals.js') }}"></script>


### PR DESCRIPTION
Added code into index.html to look for a local copy of marked.min.js in /static/node_modules.  If this isn't successfully loaded, falls back to using the CDN version.

Also added a package.json to the /static folder that will install this package by typing `npm install` if node and npm are installed.